### PR TITLE
James/airflow

### DIFF
--- a/src/dags/ingestion_dag.py
+++ b/src/dags/ingestion_dag.py
@@ -1,15 +1,10 @@
 from pendulum import datetime
 import logging
-from pathlib import Path
-import sys
 from airflow import DAG
-sys.path.append("/home/ir-hods1/projects/fair-mast-ingestion")
-from src.utils import read_shot_file
-from src.workflow import CreateSignalMetadataTask, CreateSourceMetadataTask
-from src.workflow import WorkflowManager, MetadataWorkflow
 from airflow.decorators import dag, task, task_group
 
 def signal_metadata_workflow(data_dir: str, shot: int):
+    from src.workflow import CreateSignalMetadataTask
     try:
         signal_metadata = CreateSignalMetadataTask(f"{data_dir}/signals", shot)
         signal_metadata()
@@ -17,31 +12,34 @@ def signal_metadata_workflow(data_dir: str, shot: int):
         logging.error(f"Could not parse signal metadata for shot {shot}: {e}")   
 
 def source_metadata_workflow(data_dir: str, shot: int):
+    from src.workflow import CreateSourceMetadataTask
     try:
         source_metadata = CreateSourceMetadataTask(f"{data_dir}/source", shot)
         source_metadata()
     except Exception as e:
         logging.error(f"Could not parse source metadata for shot {shot}: {e}") 
 
-@task
-def run_workflows_serial_signal(data_dir, shot_list: list):
+
+default_args = {"start_date": datetime(2021, 1, 1)}
+with DAG('metadata_processing', default_args=default_args, schedule_interval=None) as dag:
+    @task
+    def read_shots(shot_file):
+        from src.utils import read_shot_file
+        shot_list = read_shot_file(shot_file)
+        return shot_list
+    
+    @task
+    def run_workflows_serial_signal(data_dir, shot_list: list):
         n = len(shot_list)
         for i, shot in enumerate(shot_list):
             signal_metadata_workflow(data_dir, shot)
             logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
-@task
-def run_workflows_serial_source(data_dir, shot_list: list):
+    @task
+    def run_workflows_serial_source(data_dir, shot_list: list):
         n = len(shot_list)
         for i, shot in enumerate(shot_list):
             source_metadata_workflow(data_dir, shot)
             logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
-
-default_args = {"start_date": datetime(2021, 1, 1)}
-with DAG('metadata_processing', default_args=default_args) as dag:
-    @task
-    def read_shots(shot_file):
-        shot_list = read_shot_file(shot_file)
-        return shot_list
     
     @task_group
     def metadata_workflow_group(data_dir, shot_list):

--- a/src/dags/ingestion_dag.py
+++ b/src/dags/ingestion_dag.py
@@ -2,6 +2,7 @@ from pendulum import datetime
 import logging
 from pathlib import Path
 import sys
+from airflow import DAG
 sys.path.append("/home/ir-hods1/projects/fair-mast-ingestion")
 from src.utils import read_shot_file
 from src.workflow import CreateSignalMetadataTask, CreateSourceMetadataTask
@@ -17,17 +18,18 @@ def signal_metadata_workflow(data_dir: str, shot: int):
 
 def source_metadata_workflow(data_dir: str, shot: int):
     try:
-        source_metadata = CreateSourceMetadataTask(f"{data_dir}/signals", shot)
+        source_metadata = CreateSourceMetadataTask(f"{data_dir}/source", shot)
         source_metadata()
     except Exception as e:
         logging.error(f"Could not parse source metadata for shot {shot}: {e}") 
 
+@task
 def run_workflows_serial_signal(data_dir, shot_list: list):
         n = len(shot_list)
         for i, shot in enumerate(shot_list):
             signal_metadata_workflow(data_dir, shot)
             logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
-
+@task
 def run_workflows_serial_source(data_dir, shot_list: list):
         n = len(shot_list)
         for i, shot in enumerate(shot_list):
@@ -35,25 +37,17 @@ def run_workflows_serial_source(data_dir, shot_list: list):
             logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
 
 default_args = {"start_date": datetime(2021, 1, 1)}
-@dag(schedule="@daily", default_args=default_args, catchup=False)
-def create_uda_metadata():
-    
+with DAG('metadata_processing', default_args=default_args, schedule_interval='@daily') as dag:
     @task
     def read_shots(shot_file):
         shot_list = read_shot_file(shot_file)
         return shot_list
-
-    @task
-    def signal_metadata_workflow(data_dir, shot_list):
-        run_workflows_serial_signal(data_dir, shot_list)
-        
-
-    @task
-    def source_metadata_workflow(data_dir, shot_list):
+    
+    @task_group
+    def metadata_workflow_group(data_dir, shot_list):
+         run_workflows_serial_signal(data_dir, shot_list)
          run_workflows_serial_source(data_dir, shot_list)
 
-    shots = read_shots(shot_file="/home/ir-hods1/projects/fair-mast-ingestion/campaign_shots/tiny_campaign.csv")
-    signal = signal_metadata_workflow(data_dir="/home/ir-hods1/projects/fair-mast-ingestion/data/uda", shot_list=shots)
-    source = source_metadata_workflow(data_dir="/home/ir-hods1/projects/fair-mast-ingestion/data/uda", shot_list=shots)
 
-create_uda_metadata()
+    shots = read_shots(shot_file="/home/ir-hods1/projects/fair-mast-ingestion/campaign_shots/tiny_campaign.csv")
+    metadata_workflow_group(data_dir="/home/ir-hods1/projects/fair-mast-ingestion/data/uda", shot_list=shots)

--- a/src/dags/ingestion_dag.py
+++ b/src/dags/ingestion_dag.py
@@ -1,0 +1,59 @@
+from pendulum import datetime
+import logging
+from pathlib import Path
+import sys
+sys.path.append("/home/ir-hods1/projects/fair-mast-ingestion")
+from src.utils import read_shot_file
+from src.workflow import CreateSignalMetadataTask, CreateSourceMetadataTask
+from src.workflow import WorkflowManager, MetadataWorkflow
+from airflow.decorators import dag, task, task_group
+
+def signal_metadata_workflow(data_dir: str, shot: int):
+    try:
+        signal_metadata = CreateSignalMetadataTask(f"{data_dir}/signals", shot)
+        signal_metadata()
+    except Exception as e:
+        logging.error(f"Could not parse signal metadata for shot {shot}: {e}")   
+
+def source_metadata_workflow(data_dir: str, shot: int):
+    try:
+        source_metadata = CreateSourceMetadataTask(f"{data_dir}/signals", shot)
+        source_metadata()
+    except Exception as e:
+        logging.error(f"Could not parse source metadata for shot {shot}: {e}") 
+
+def run_workflows_serial_signal(data_dir, shot_list: list):
+        n = len(shot_list)
+        for i, shot in enumerate(shot_list):
+            signal_metadata_workflow(data_dir, shot)
+            logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
+
+def run_workflows_serial_source(data_dir, shot_list: list):
+        n = len(shot_list)
+        for i, shot in enumerate(shot_list):
+            source_metadata_workflow(data_dir, shot)
+            logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
+
+default_args = {"start_date": datetime(2021, 1, 1)}
+@dag(schedule="@daily", default_args=default_args, catchup=False)
+def create_uda_metadata():
+    
+    @task
+    def read_shots(shot_file):
+        shot_list = read_shot_file(shot_file)
+        return shot_list
+
+    @task
+    def signal_metadata_workflow(data_dir, shot_list):
+        run_workflows_serial_signal(data_dir, shot_list)
+        
+
+    @task
+    def source_metadata_workflow(data_dir, shot_list):
+         run_workflows_serial_source(data_dir, shot_list)
+
+    shots = read_shots(shot_file="/home/ir-hods1/projects/fair-mast-ingestion/campaign_shots/tiny_campaign.csv")
+    signal = signal_metadata_workflow(data_dir="/home/ir-hods1/projects/fair-mast-ingestion/data/uda", shot_list=shots)
+    source = source_metadata_workflow(data_dir="/home/ir-hods1/projects/fair-mast-ingestion/data/uda", shot_list=shots)
+
+create_uda_metadata()

--- a/src/dags/ingestion_dag.py
+++ b/src/dags/ingestion_dag.py
@@ -37,7 +37,7 @@ def run_workflows_serial_source(data_dir, shot_list: list):
             logging.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
 
 default_args = {"start_date": datetime(2021, 1, 1)}
-with DAG('metadata_processing', default_args=default_args, schedule_interval='@daily') as dag:
+with DAG('metadata_processing', default_args=default_args) as dag:
     @task
     def read_shots(shot_file):
         shot_list = read_shot_file(shot_file)


### PR DESCRIPTION
These are the steps I've had to do to get airflow running, there is probably cleaner ways to do this but this worked for me. I cannot get it going within the ingestion repo yet but will look at it in the future:

Create a directory outside the fair-mast-ingestion repo, call it `airflow-dir` for now. Run pretty much the same instructions for the ingestion to get the environment setup correctly:

```sh
module load python-3.9.6-gcc-5.4.0-sbr552h
python -m venv airflow-venv
source airflow-venv/bin/activate
```

```sh
python -m pip install -U pip
python -m pip install -e ../fair-mast-ingestion/
```

```sh
git clone git@git.ccfe.ac.uk:MAST-U/mastcodes.git
cd mastcodes
```

Edit `uda/python/setup.py` and change the "version" to 1.3.9.

```sh
python -m pip install uda/python
cd ..
source ~/rds/rds-ukaea-mast-sPGbyCAPsJI/uda-ssl.sh
```

Now we install Airflow, and get the config set up to point to the correct areas.

```sh
pip install "apache-airflow[celery]==2.10.0" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-3.8.txt"
```

Run Airflow for the first time, this will put an `airflow` dir in your `airflow-dir` along with the config file. 
```sh
NO_PROXY="*" AIRFLOW_HOME="$(pwd)/airflow" airflow standalone
```

You can now shut down the process. Edit `/airflow/airflow.cfg` and change the following:

`dags_folder = "PATH"/fair-mast-ingestion/src/dags/`
`load_examples = False`

Reset the database and re-run:

```sh
NO_PROXY="*" AIRFLOW_HOME="$(pwd)/airflow" airflow db reset
NO_PROXY="*" AIRFLOW_HOME="$(pwd)/airflow" airflow standalone
```

Make note of the username and password in the terminal, and head to `http://localhost:8080/` to log in.

The metadata-processing DAG should appear in your DAGs. Before triggering the workflow, please change the paths within `src/dags/ingestion_dag.py` to your own. This is something I need to fix still.

