### PR TITLE
Update to add data for DEFUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,11 @@ mpirun -np 16 python3 -m src.main data/local campaign_shots/tiny_campaign.csv --
 
 This will submit a job to the freia job queue that will ingest all of the shots in the tiny campaign and push them to the s3 bucket.
 
+## CPF Metadata
+
+To parse CPF metadata we can use the following script (only on Friea):
+
+```sh
+qsub ./jobs/freia_write_cpf.qsub campaign_shots/tiny_campaign.csv
+```
+

--- a/jobs/freia_write_cpf.qsub
+++ b/jobs/freia_write_cpf.qsub
@@ -1,20 +1,17 @@
 #!/bin/bash
 
-# Verify options and abort if there is a error
-#$ -w e
-
 # Choose parallel environment
 #$ -pe mpi 16
 
 # Specify the job name in the queue system
-#$ -N fairmast-dataset-writer
+#$ -N fairmast-cpf-writer
 
 # Start the script in the current working directory
 #$ -cwd
 
 # Time requirements
-#$ -l h_rt=120:00:00
-#$ -l s_rt=120:00:00
+#$ -l h_rt=48:00:00
+#$ -l s_rt=48:00:00
 
 # Activate your environment here!
 module load python/3.9
@@ -28,4 +25,4 @@ shot_file=$1
 export PATH="/home/rt2549/dev/:$PATH"
 
 # Run script
-python3 -m src.metadata.create_cpf_metadata $shot_file
+python3 -m src.create_cpf_metadata $shot_file

--- a/jobs/ingest.csd3.slurm.sh
+++ b/jobs/ingest.csd3.slurm.sh
@@ -9,8 +9,7 @@
 #SBATCH -N 2
 
 
-summary_file=$1
-bucket_path=$2
+bucket_path=$1
 num_workers=$SLURM_NTASKS
 
 random_string=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16)
@@ -19,5 +18,18 @@ metadata_dir="/rds/project/rds-sPGbyCAPsJI/data/uda"
 
 source /rds/project/rds-sPGbyCAPsJI/uda-ssl.sh
 
+summary_file="./campaign_shots/M9.csv"
 mpirun -np $num_workers \
-    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:3}
+    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:2}
+summary_file="./campaign_shots/M8.csv"
+mpirun -np $num_workers \
+    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:2}
+summary_file="./campaign_shots/M7.csv"
+mpirun -np $num_workers \
+    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:2}
+summary_file="./campaign_shots/M6.csv"
+mpirun -np $num_workers \
+    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:2}
+summary_file="./campaign_shots/M5.csv"
+mpirun -np $num_workers \
+    python3 -m src.main $temp_dir $summary_file --metadata_dir $metadata_dir --bucket_path $bucket_path --upload --force --source_names ${@:2}

--- a/jobs/submit.cpf.sh
+++ b/jobs/submit.cpf.sh
@@ -1,0 +1,5 @@
+ qsub jobs/freia_write_cpf.qsub campaign_shots/M9.csv 
+ qsub jobs/freia_write_cpf.qsub campaign_shots/M8.csv 
+ qsub jobs/freia_write_cpf.qsub campaign_shots/M7.csv 
+ qsub jobs/freia_write_cpf.qsub campaign_shots/M6.csv 
+ qsub jobs/freia_write_cpf.qsub campaign_shots/M5.csv 

--- a/mappings/mast/dimensions.json
+++ b/mappings/mast/dimensions.json
@@ -7179,5 +7179,77 @@
     },
     "xdc/z_t_ztest": {
         "time1": "time"
+    },
+    "xim/cii_hu10_u": {
+        "sec": "time"
+    },
+    "xim/da_bo10": {
+        "sec": "time"
+    },
+    "xim/da_hl11_l1": {
+        "sec": "time"
+    },
+    "xim/da_h11_r1": {
+        "sec": "time"
+    },
+    "xim/da_hm10_r": {
+        "sec": "time"
+    },
+    "xim/da_hm10_r1": {
+        "sec": "time"
+    },
+    "xim/da_hm10_t": {
+        "sec": "time"
+    },
+    "xim/da_hu10_r1": {
+        "sec": "time"
+    },
+    "xim/da_hu10_t": {
+        "sec": "time"
+    },
+    "xim/da_hu10_u1": {
+        "sec": "time"
+    },
+    "xim/da_hto10": {
+        "sec": "time"
+    },
+    "xim/dg_hu10_r2": {
+        "sec": "time"
+    },
+    "xim/heii_eceleste": {
+        "sec": "time"
+    },
+    "xim/light_end": {
+        "sec": "time"
+    },
+    "xim/light_start": {
+        "sec": "time"
+    },
+    "xim/mass_end": {
+        "sec": "time"
+    },
+    "xim/mass_start": {
+        "sec": "time"
+    },
+    "xim/pellet_halpha_2": {
+        "sec": "time"
+    },
+    "xim/pellet_time": {
+        "sec": "time"
+    },
+    "xim/preion_trig": {
+        "sec": "time"
+    },
+    "xim/target": {
+        "sec": "time"
+    },
+    "xim/trigger": {
+        "sec": "time"
+    },
+    "xim/ts_yag": {
+        "sec": "time"
+    },
+    "xim/xsa_logic_out": {
+        "sec": "time"
     }
 }

--- a/mappings/mast/dimensions.json
+++ b/mappings/mast/dimensions.json
@@ -14,6 +14,24 @@
     "ada/geo_full": {
         "dim_0": "dim_1"
     },
+    "asm/hm_periods": {
+        "time": "hm_time"
+    },
+    "asm/hm_rating": {
+        "time": "hm_time"
+    },
+    "asm/out_nn_pattern": {
+        "time": "out_time"
+    },
+    "asm/out_nn_rating": {
+        "time": "out_time"
+    },
+    "asm/out_rating": {
+        "time": "out_time"
+    },
+    "asm/out_signal": {
+        "time": "out_time"
+    },
     "asx/elm_freqs": {
         "time": "npts"
     },

--- a/mappings/mast/dimensions.json
+++ b/mappings/mast/dimensions.json
@@ -5759,7 +5759,10 @@
         "timesec": "time"
     },
     "ayc/acqiris_time": {
-        "t": "time"
+        "t": "acqiris_time"
+    },
+    "ayc/angle": {
+        "arb": "radial_index"
     },
     "ayc/aspectra": {
         "t": "time",
@@ -5775,7 +5778,7 @@
         "radialindex": "radial_index"
     },
     "ayc/instrument_dr": {
-        "t": "time",
+        "t": "instrument_time",
         "radialindex": "radial_index"
     },
     "ayc/interferometer_corr": {
@@ -5839,7 +5842,7 @@
         "t": "time"
     },
     "ayc/xyc_time": {
-        "t": "time"
+        "t": "xyc_time"
     },
     "ayc/yag_nelint": {
         "t": "time"

--- a/src/create_cpf_metadata.py
+++ b/src/create_cpf_metadata.py
@@ -1,0 +1,56 @@
+import argparse
+import numpy as np
+import pandas as pd
+import multiprocessing as mp
+from functools import partial
+from pathlib import Path
+from rich.progress import track
+from pycpf import pycpf
+
+
+def read_cpf_for_shot(shot, columns):
+    cpf_data = {}
+    for name in columns:
+        entry = pycpf.query(name, f"shot = {shot}") 
+        value = entry[name][0] if name in entry else np.nan
+        cpf_data[name] = value 
+
+    cpf_data['shot_id'] = shot
+    return cpf_data
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="FAIR MAST Ingestor",
+        description="Parse the MAST archive and writer to Zarr/NetCDF/HDF files",
+    )
+
+    parser.add_argument("shot_file")
+    args = parser.parse_args()
+
+    shot_file = args.shot_file
+    shot_ids = pd.read_csv(shot_file)
+    shot_ids = shot_ids['shot_id'].values
+
+    columns = pycpf.columns()
+    columns = pd.DataFrame(columns, columns=['name', 'description'])
+    columns.to_parquet(f'data/{Path(shot_file).stem}_cpf_columns.parquet')
+
+    pool = mp.Pool(16)
+    column_names = columns['name'].values
+    func = partial(read_cpf_for_shot, columns=column_names)
+    mapper = pool.imap_unordered(func, shot_ids)
+    rows = [item for item in track(mapper, total=len(shot_ids))]
+    cpf_data = pd.DataFrame(rows)
+
+    # Convert objects to strings
+    for column in cpf_data.columns:
+        dtype = cpf_data[column].dtype
+        if isinstance(dtype, object):
+            cpf_data[column] = cpf_data[column].astype(str)
+
+    cpf_data.to_parquet(f'data/{Path(shot_file).stem}_cpf_data.parquet')
+    print(cpf_data)
+   
+
+if __name__ == "__main__":
+    main()

--- a/src/transforms.py
+++ b/src/transforms.py
@@ -1047,6 +1047,14 @@ class MASTPipelineRegistry(PipelineRegistry):
                     TransformUnits(),
                 ]
             ),
+            "xim": Pipeline(
+                [
+                    MapDict(RenameDimensions()),
+                    MapDict(StandardiseSignalDataset("xim")),
+                    MergeDatasets(),
+                    TransformUnits(),
+                ]
+            ),
             "xmo": Pipeline(
                 [
                     MapDict(RenameDimensions()),

--- a/src/transforms.py
+++ b/src/transforms.py
@@ -74,6 +74,19 @@ class DropDatasets:
             datasets.pop(key)
         return datasets
 
+class DropCoordinates:
+
+    def __init__(self, name, keys: list[str]) -> None:
+        self.name = name
+        self.keys = keys
+
+    def __call__(self, datasets: dict[str, xr.Dataset]) -> dict[str, xr.Dataset]:
+        for name, dataset in datasets.items():
+            if name == self.name:
+                for key in self.keys:
+                    dataset = dataset.drop_indexes(key)
+                    datasets[name] = dataset.drop_vars(key)
+        return datasets
 
 class StandardiseSignalDataset:
 
@@ -133,6 +146,11 @@ class RenameVariables:
         dataset = dataset.compute()
         return dataset
 
+class AlignDatasets:
+    
+    def __call__(self, dataset_dict: dict[str, xr.Dataset]) -> xr.Dataset:
+        datasets = xr.align(*list(dataset_dict.values()), join='left')
+        return dict(zip(dataset_dict.keys(), datasets))
 
 class MergeDatasets:
 
@@ -634,8 +652,16 @@ class MASTPipelineRegistry(PipelineRegistry):
                 [
                     MapDict(RenameDimensions()),
                     MapDict(StandardiseSignalDataset("ayc")),
+                    DropCoordinates('ayc/segment_number', ['time']),
+                    DropDatasets(['ayc/time']),
+                    AlignDatasets(),
                     MergeDatasets(),
                     TransformUnits(),
+                    RenameVariables(
+                        {
+                            "r": "radius",
+                        }
+                    ),
                 ]
             ),
             "aye": Pipeline(


### PR DESCRIPTION
Updating the ingestion to adjust existing and include additional data sources from MAST.

- Update CPF parsing scripts
- `ayc` - update to fix some issues with `time` dimensions.
- `xim` - add as new source
- `asm` - update to fix some time dimensions

To test:

Try running
```
mpirun -np 4 python3 -m src.main data/local campaign_shots/tiny_campaign.csv --metadata_dir data/uda --source_names ayc asm xim --file_format nc
```
On CSD3, check that the output is sensible.

Code review.