### PR TITLE
Implementation of LakeFS

### DIFF
--- a/src/lake_fs.py
+++ b/src/lake_fs.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import logging
 from lakefs.client import Client
+from src.task import CleanupDatasetTask
 import lakefs
 import subprocess
 from datetime import datetime
@@ -101,6 +102,16 @@ def validate_data_directory(local_folder):
         sys.exit(1)
     logging.info(f"Data directory '{local_folder}' is valid.")
 
+def perform_cleanup(data_dir):
+    logging.info("Starting dataset cleanup process...")
+    try:
+        cleanup = CleanupDatasetTask(data_dir)
+        cleanup()  
+        logging.info(f"Cleanup successful for directory: {data_dir}")
+    except Exception as e:
+        logging.error(f"Error during cleanup: {e}")
+        raise
+
 
 def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -124,6 +135,8 @@ def main():
     lakefs_manager.merge_branch(branch)
     lakefs_manager.delete_branch(branch.id)
 
+    perform_cleanup(args.data_dir)
+    
 
 if __name__ == "__main__":
     main()

--- a/src/lake_fs.py
+++ b/src/lake_fs.py
@@ -1,0 +1,103 @@
+import os
+import glob
+import config
+from lakefs.client import Client
+import lakefs
+import subprocess
+from datetime import datetime
+
+class LakeFSManager:
+    def __init__(self, host, username, password, repo_name):
+        self.client = Client(host=host, username=username, password=password)
+        self.repo_name = repo_name
+        self.repo = lakefs.Repository(repo_name, client=self.client)
+
+    def execute_command(self, command):
+        try:
+            result = subprocess.run(command, check=True, capture_output=True, text=True)
+            print("Output:", result.stdout)
+            return result
+        except subprocess.CalledProcessError as e:
+            print("An error occurred while executing the command.")
+            print("Error message:", e.stderr)
+            return e
+
+    def create_branch(self):
+        # Generate a unique branch name based on the current date and time
+        print("Creating branch for ingestion...")
+        branch_name = datetime.now().strftime("branch-%Y%m%d-%H%M%S")
+        branch = self.repo.branch(branch_name).create(source_reference="main")
+        return branch
+
+    def upload_files_to_branch(self, branch_name, local_folder="data/local"):
+        print("Uploading files from data directory to branch...")
+        command = [
+                "lakectl", "fs", "upload",
+                f"lakefs://{self.repo_name}/{branch_name}/",
+                "-s", local_folder,
+                "-r"
+            ]
+        self.execute_command(command)
+
+    def commit_branch(self, branch_name, message):
+        print("Committing changes to branch...")
+        command = [
+            "lakectl", "commit",
+            f"lakefs://{self.repo_name}/{branch_name}/",
+            "-m", message
+        ]
+        result = self.execute_command(command)
+
+        if result.returncode != 0:
+            print(f"Commit failed for branch '{branch_name}'. Deleting branch and exiting.")
+            self.delete_branch(branch_name)
+            exit()
+
+    def show_diff(self, branch):
+        main_branch = self.repo.branch("main")
+        changes = list(main_branch.diff(other_ref=branch))
+        print(f"Number of changes made to main: {len(changes)}")
+
+    def merge_branch(self, branch):
+        print("Merging branch to main...")
+        main_branch = self.repo.branch("main")
+        res = branch.merge_into(main_branch)
+        return res
+
+    def delete_branch(self, branch_name):
+        print("Deleting branch.")
+        command = [
+            "lakectl", "branch", "delete",
+            f"lakefs://{self.repo_name}/{branch_name}",
+            "--yes"
+        ]
+        self.execute_command(command)
+
+if __name__ == "__main__":
+    manager = LakeFSManager(
+        host="http://127.0.0.1:8000/",
+        username=config.username,
+        password=config.password,
+        repo_name="example-repo"
+    )
+
+    # Create a new branch with a unique name
+    branch = manager.create_branch()
+
+    # Upload a local file to the new branch
+    manager.upload_files_to_branch(
+        branch_name=branch.id,
+        local_folder="data"
+    )
+
+    # Commit the uploaded files to the branch
+    manager.commit_branch(
+        branch_name=branch.id,
+        message="Uploaded new files."
+    )
+
+    # Show differences between the main branch and the new branch
+    manager.show_diff(branch)
+
+    # Merge the new branch into the main branch
+    manager.merge_branch(branch)

--- a/src/main.py
+++ b/src/main.py
@@ -68,6 +68,16 @@ def main():
         workflow_manager.run_workflows(shot_list, parallel = not args.serial)
         logging.info(f"Finished source {source}")
 
+    from mpi4py import MPI
+    # Ensure only the process with rank 0 versions the data
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    if rank == 1:
+        from src.task import VersionDataTask
+        repo_name = "example-repo"
+        version = VersionDataTask(args.dataset_path, repo_name)
+        version()
 
 if __name__ == "__main__":
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -68,16 +68,5 @@ def main():
         workflow_manager.run_workflows(shot_list, parallel = not args.serial)
         logging.info(f"Finished source {source}")
 
-    from mpi4py import MPI
-    # Ensure only the process with rank 0 versions the data
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-
-    if rank == 1:
-        from src.task import VersionDataTask
-        repo_name = "example-repo"
-        version = VersionDataTask(args.dataset_path, repo_name)
-        version()
-
 if __name__ == "__main__":
     main()

--- a/src/task.py
+++ b/src/task.py
@@ -12,37 +12,8 @@ from src.mast import MASTClient
 from src.reader import DatasetReader, SignalMetadataReader, SourceMetadataReader
 from src.writer import DatasetWriter
 from src.uploader import UploadConfig
-from src.lake_fs import LakeFSManager
 
 logging.basicConfig(level=logging.INFO)
-
-class VersionDataTask:
-    def __init__(self, local_path, repo_name):
-        self.local_path = local_path
-        self.lakefs_manager = LakeFSManager(repo_name)
-        self.branch = None
-
-    def __call__(self):
-        # 1. Create a new branch
-        self.branch = self.lakefs_manager.create_branch()
-
-        # 2. Upload the files from the local path to the newly created branch
-        self.lakefs_manager.upload_files_to_branch(
-            branch_name=self.branch.id,
-            local_folder=self.local_path
-        )
-
-        # 3. Commit the changes to the branch
-        self.lakefs_manager.commit_branch(
-            branch_name=self.branch.id,
-            message="Uploaded new files."
-        )
-
-        # 4. Show differences between the main branch and the new branch
-        self.lakefs_manager.show_diff(self.branch)
-
-        # 5. Merge the new branch into the main branch
-        self.lakefs_manager.merge_branch(self.branch)
 
 
 class CleanupDatasetTask:

--- a/src/task.py
+++ b/src/task.py
@@ -12,8 +12,37 @@ from src.mast import MASTClient
 from src.reader import DatasetReader, SignalMetadataReader, SourceMetadataReader
 from src.writer import DatasetWriter
 from src.uploader import UploadConfig
+from src.lake_fs import LakeFSManager
 
 logging.basicConfig(level=logging.INFO)
+
+class VersionDataTask:
+    def __init__(self, local_path, repo_name):
+        self.local_path = local_path
+        self.lakefs_manager = LakeFSManager(repo_name)
+        self.branch = None
+
+    def __call__(self):
+        # 1. Create a new branch
+        self.branch = self.lakefs_manager.create_branch()
+
+        # 2. Upload the files from the local path to the newly created branch
+        self.lakefs_manager.upload_files_to_branch(
+            branch_name=self.branch.id,
+            local_folder=self.local_path
+        )
+
+        # 3. Commit the changes to the branch
+        self.lakefs_manager.commit_branch(
+            branch_name=self.branch.id,
+            message="Uploaded new files."
+        )
+
+        # 4. Show differences between the main branch and the new branch
+        self.lakefs_manager.show_diff(self.branch)
+
+        # 5. Merge the new branch into the main branch
+        self.lakefs_manager.merge_branch(self.branch)
 
 
 class CleanupDatasetTask:

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -71,23 +71,21 @@ class S3IngestionWorkflow:
         )
 
         upload = UploadDatasetTask(local_path, self.upload_config)
-        cleanup = CleanupDatasetTask(local_path)
+        #cleanup = CleanupDatasetTask(local_path)
 
         try:
             url = self.upload_config.url + f"{shot}.{self.file_format}"
             if self.force or not self.fs.exists(url):
                 create()
 
-                # Do LakeFS stuff here, after the files have been created. This try block already checks whether the 
-                # file already exists on S3, and either skips or forces it. My LakeFS code skips if there is no diff
-                # so should catch everything. 
+
                 upload()
 
             else:
                 logging.info(f"Skipping shot {shot} as it already exists")
         except Exception as e:
             logging.error(f"Failed to run workflow with error {type(e)}: {e}")
-        cleanup()
+        #cleanup()
 
 class LocalIngestionWorkflow:
 
@@ -124,10 +122,7 @@ class LocalIngestionWorkflow:
 
         try:
             create()
-            from src.task import VersionDataTask
-            repo_name = "example-repo"
-            version = VersionDataTask("data/local", repo_name)
-            version()
+
         except Exception as e:
             import traceback
             trace = traceback.format_exc()
@@ -142,7 +137,7 @@ class WorkflowManager:
     def __init__(self, workflow):
         self.workflow = workflow
 
-    def run_workflows(self, shot_list: list[int], parallel=False):
+    def run_workflows(self, shot_list: list[int], parallel=True):
         if parallel:
             self._run_workflows_parallel(shot_list)
         else:

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -5,7 +5,6 @@ from dask.distributed import Client, as_completed
 from src.task import (
     CreateDatasetTask,
     UploadDatasetTask,
-    CleanupDatasetTask,
     CreateSignalMetadataTask,
     CreateSourceMetadataTask,
 )
@@ -71,21 +70,17 @@ class S3IngestionWorkflow:
         )
 
         upload = UploadDatasetTask(local_path, self.upload_config)
-        #cleanup = CleanupDatasetTask(local_path)
 
         try:
             url = self.upload_config.url + f"{shot}.{self.file_format}"
             if self.force or not self.fs.exists(url):
                 create()
-
-
                 upload()
 
             else:
                 logging.info(f"Skipping shot {shot} as it already exists")
         except Exception as e:
             logging.error(f"Failed to run workflow with error {type(e)}: {e}")
-        #cleanup()
 
 class LocalIngestionWorkflow:
 


### PR DESCRIPTION
The main changes made to the actual code base are creating a LakeFS workflow (src/lake_fs.py) and moving the `cleanup` process that was previously apart of the ingestion workflow into this LakeFS workflow, to take advantage of the fact that the ingestion files are written to the disk locally during the whole process.

At the moment, I have a LakeFS server and Postgres server running on the STFC machine. Then, on the machine you want to run your ingestion/versioning code:

- Set up a SSH tunnel into the STFC machine. With this, we can access the LakeFS setup UI when we first run the LakeFS server which gives us the access key and secret key to the server. We want to keep this somewhere safe. Create a repository through the UI and point to the S3 storage we want to use. Import all the existing date from the S3 storage through the big green "Import" button on the UI.
- (Optional) If you want to create a new LakeFS repo that points to an S3 object store that already has a repo associated, then you will need to remove the "/data" and "_lakefs" directories from that S3 store first using s5cmd.
- You will need to install LakeCTL (download the .tar with wget, un-tar it) so that we can use `lakectl config` and input the access key and secret key that the LakeFS UI setup gave us earlier. This will allow our machine to access the LakeFS server.
- Run the command `python src/lake_fs.py --repo REPO-NAME --data-dir /LOCATION/OF/DATA/ --commit-message "Ingesting my data"`

The idea is to run the ingestion workflow as normal, either locally or to s3, and then run the LakeFS versioning code when we want to version. This will upload all of the data that is written to 'data/local' (for example, can be anywhere we want) and then remove those files similar to the `cleanup()` process that used to be apart of the ingestion workflow itself.

The reasoning for seperating LakeFS from the ingestion workflow is with the MPI processes that we use to speed up ingestion. I tried to work around this by only letting one MPI rank do the versioning task but found it cumbersome. I think having it seperate as well allows us to pick and choose when we want to version our data. But perhaps there is a better way around this. 