### PR TITLE
Swap to using time to be the last dimension

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -39,6 +39,7 @@ datasets:
         source: "EFM_Q(R)" 
         units: 'dimensionless'
         imas: "equilibrium.time_slice[:].profiles_1d.q"
+        dimension_order: ['profile_r', 'time']
         dimensions:
           time:
             units: 's'
@@ -49,6 +50,7 @@ datasets:
       j_tor:
         source: "EFM_PLASMA_CURR(R,Z)" 
         imas: "equilibrium.time_slice[:].profiles_2d[:].j_tor"
+        dimension_order: ['z', 'major_radius', 'time']
         dimensions:
           time:
             units: 's'
@@ -65,6 +67,7 @@ datasets:
       psi:
         source: "EFM_PSI(R,Z)" 
         imas: "equilibrium.time_slice[:].profiles_2d[:].psi"
+        dimension_order: ['z', 'major_radius', 'time']
         dimensions:
           time:
             units: 's'
@@ -223,6 +226,7 @@ datasets:
         source: "EFM_LCFS(R)_(C)" 
         imas: "equilibrium.time_slice[:].boundary.lcfs.r"
         fill_value: 9.98876992e+08
+        dimension_order: ['n_boundary_coords', 'time']
         dimensions:
           time:
             imas: "equilibrium.time_slice[:].time"
@@ -232,6 +236,7 @@ datasets:
         source: "EFM_LCFS(Z)_(C)" 
         imas: "equilibrium.time_slice[:].boundary.lcfs.z"
         fill_value: 9.98876992e+08
+        dimension_order: ['n_boundary_coords', 'time']
         dimensions:
           time:
             imas: "equilibrium.time_slice[:].time"
@@ -1169,6 +1174,7 @@ datasets:
               shot_min: 1
               shot_max: 22831
         imas: "thomson_scattering.channel[:].t_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].t_e.time"
@@ -1194,6 +1200,7 @@ datasets:
               shot_min: 1
               shot_max: 22831
         imas: "thomson_scattering.channel[:].n_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].n_e.time"
@@ -1218,6 +1225,7 @@ datasets:
             shot_range:
               shot_min: 1
               shot_max: 22831
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
           major_radius:
@@ -1247,6 +1255,7 @@ datasets:
       t_i:
         source: "ACT_SS_TEMPERATURE" 
         imas: "charge_exchange.channel[:].ion[:].t_i"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "charge_exchange.time"
@@ -1254,14 +1263,17 @@ datasets:
           major_radius:
             imas: "charge_exchange.channel[:].position.r" 
 
+
       v_i:
         source: "ACT_SS_VELOCITY" 
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "charge_exchange.time"
           
           major_radius:
             imas: "charge_exchange.channel[:].position.r" 
+
             
   soft_x_rays:
     interpolate:
@@ -1439,6 +1451,7 @@ datasets:
       camera_lower:
         source: "RBA"
         imas: "camera_visible.channel[:].detector[:].frame[:].image_raw"
+        dimension_order: ['height_a', 'width_a', 'time']
         dimensions:
           time:
             imas: "camera_visible.channel[:].detector[:].frame[:].time"
@@ -1447,6 +1460,7 @@ datasets:
       camera_center:
         source: "RBB"
         imas: "camera_visible.channel[:].detector[:].frame[:].image_raw"
+        dimension_order: ['height_b', 'width_b', 'time']
         dimensions:
           time:
             imas: "camera_visible.channel[:].detector[:].frame[:].time"
@@ -1455,6 +1469,7 @@ datasets:
       camera_color:
         source: "RGB"
         imas: "camera_visible.channel[:].detector[:].frame[:].image_raw"
+        dimension_order: ['height_c', 'width_c', 'time']
         dimensions:
           time:
             imas: "camera_visible.channel[:].detector[:].frame[:].time"

--- a/mappings/level2/mastu.yml
+++ b/mappings/level2/mastu.yml
@@ -74,6 +74,7 @@ datasets:
 
       total_pressure:
         source: "epm/output/radialProfiles/totalPressure"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "epm/time"

--- a/mappings/level2/mastu.yml
+++ b/mappings/level2/mastu.yml
@@ -28,6 +28,7 @@ datasets:
         source: "epm/output/fluxFunctionProfiles/q" 
         units: 'dimensionless'
         imas: "equilibrium.time_slice[:].profiles_1d.q"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "epm/time"
@@ -40,6 +41,7 @@ datasets:
       j_tor:
         source: "epm/output/profiles2D/jphi" 
         imas: "equilibrium.time_slice[:].profiles_2d[:].j_tor"
+        dimension_order: ['major_radius', 'z', 'time']
         dimensions:
           time:
             source: "epm/time"
@@ -56,6 +58,7 @@ datasets:
       psi:
         source: "epm/output/profiles2D/poloidalFlux" 
         imas: "equilibrium.time_slice[:].profiles_2d[:].psi"
+        dimension_order: ['major_radius', 'z', 'time']
         dimensions:
           time:
             source: "epm/time"
@@ -229,6 +232,7 @@ datasets:
       lcfs_r:
         source: "EPM/OUTPUT/SEPARATRIXGEOMETRY/RBOUNDARY" 
         imas: "equilibrium.time_slice[:].boundary.lcfs.r"
+        dimension_order: ['n_boundary_coords', 'time']
         dimensions:
           time:
             source: "epm/time"
@@ -237,6 +241,7 @@ datasets:
       lcfs_z:
         source: "EPM/OUTPUT/SEPARATRIXGEOMETRY/ZBOUNDARY" 
         imas: "equilibrium.time_slice[:].boundary.lcfs.z"
+        dimension_order: ['n_boundary_coords', 'time']
         dimensions:
           time:
             source: "epm/time"
@@ -968,6 +973,7 @@ datasets:
       t_e:
         imas: "thomson_scattering.channel[:].t_e.data"
         source: "ayc/t_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].t_e.time"
@@ -979,6 +985,7 @@ datasets:
       n_e:
         imas: "thomson_scattering.channel[:].n_e.data"
         source: "ayc/n_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].n_e.time"
@@ -989,6 +996,7 @@ datasets:
 
       p_e:
         source: "ayc/p_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "ayc/time"
@@ -1025,6 +1033,7 @@ datasets:
       t_e:
         imas: "thomson_scattering.channel[:].t_e.data"
         source: "ayd/t_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].t_e.time"
@@ -1036,6 +1045,7 @@ datasets:
       n_e:
         imas: "thomson_scattering.channel[:].n_e.data"
         source: "ayd/n_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             imas: "thomson_scattering.channel[:].n_e.time"
@@ -1046,6 +1056,7 @@ datasets:
 
       p_e:
         source: "ayd/p_e"
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "ayd/time"
@@ -1081,6 +1092,7 @@ datasets:
       t_i:
         imas: "charge_exchange.channel[:].t_i_average.data"
         source: "act/cel3/ss/pvb/c5291/temperature" 
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "act/cel3/ss/time"
@@ -1090,6 +1102,7 @@ datasets:
 
       v_i:
         source: "act/cel3/ss/pvb/c5291/velocity" 
+        dimension_order: ['major_radius', 'time']
         dimensions:
           time:
             source: "act/cel3/ss/time"
@@ -1281,6 +1294,7 @@ datasets:
       camera_center:
         source: "RBA"
         imas: "camera_visible.channel[:].detector[:].frame[:].image_raw"
+        dimension_order: ['height_a', 'width_a', 'time']
         dimensions:
           time:
             imas: "camera_visible.channel[:].detector[:].frame[:].time"

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -65,6 +65,7 @@ class ProfileInfo(BaseModel):
     fill_value: Optional[float] = None
     target_units: Optional[str] = None
     description: Optional[str] = ""
+    dimension_order: Optional[list[str]] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -115,14 +115,22 @@ class DatasetReader:
         item = item.sortby([name for name in dim_names if "channel" not in name])
         item = item.drop_duplicates(dim=...)
 
+        if profile.dimension_order is not None:
+            item = item.transpose(*profile.dimension_order)
+
         if item.isnull().all():
             raise MissingProfileError(
                 f"All values are NaN for shot {self._shot} and profile {profile_name}"
             )
 
         if source.background_correction:
-            start, end = source.background_correction.tmin, source.background_correction.tmax
-            logger.info(f"Applying background subtraction for {profile_name} using window {start}-{end}")
+            start, end = (
+                source.background_correction.tmin,
+                source.background_correction.tmax,
+            )
+            logger.info(
+                f"Applying background subtraction for {profile_name} using window {start}-{end}"
+            )
             subtractor = BackgroundSubtractionTransform(start, end)
             item = subtractor.transform_array(item)
         return item


### PR DESCRIPTION
Dimension ordering is inconsistent within a Zarr file. Usually this does not matter too much if you use xarray, but we should still be consistent.

**To test:**
 - Check that the dimensions ordering is consistent and that time is now the last dimension for `charge_exchange`, `thomson_scattering`, `equilibrium`, and `camera_visible` sources.

closes #63 