### PR TITLE
Fix running unit tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ fair-mast-*.e*
 fair-mast-*.o*
 .s5cfg*
 *.db
+
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = {file = ["requirements.txt"]}
 dev = [
     "pytest",
     "pytest-mock",
+    "pytest-env",
     "ruff"
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+env =
+    UDA_HOST="uda2.mast.l"
+    UDA_META_PLUGINNAME="MASTU_DB"
+    UDA_METANEW_PLUGINNAME="MAST_DB"

--- a/src/core/writer.py
+++ b/src/core/writer.py
@@ -52,10 +52,10 @@ class DatasetWriter(ABC):
 
 class ZarrDatasetWriter(DatasetWriter):
     def __init__(
-        self, output_path: str, mode: str = "single", zarr_format: int = 2, **kwargs
+        self, output_path: str, mode: str = "single", zarr_version: int = 2, **kwargs
     ):
         super().__init__(output_path)
-        self.version = zarr_format
+        self.version = zarr_version
         self.mode = mode
 
     @property
@@ -73,7 +73,11 @@ class ZarrDatasetWriter(DatasetWriter):
     def _write_single_zarr(self, file_name: str, name: str, dataset: xr.Dataset):
         file_name = self.output_path / file_name
         dataset.to_zarr(
-            file_name, group=name, mode="w", zarr_format=self.version, consolidated=True
+            file_name,
+            group=name,
+            mode="w",
+            zarr_version=self.version,
+            consolidated=True,
         )
         zarr.consolidate_metadata(file_name)
 
@@ -81,7 +85,7 @@ class ZarrDatasetWriter(DatasetWriter):
         file_name = Path(file_name)
         path = self.output_path / f"{file_name.stem}/{name}.zarr"
         path.parent.mkdir(exist_ok=True, parents=True)
-        dataset.to_zarr(path, mode="a", zarr_format=self.version, consolidated=True)
+        dataset.to_zarr(path, mode="a", zarr_version=self.version, consolidated=True)
         zarr.consolidate_metadata(path)
 
 

--- a/tests/core/test_loader.py
+++ b/tests/core/test_loader.py
@@ -6,7 +6,18 @@ import xarray as xr
 from src.core.load import SALLoader, UDALoader, ZarrLoader
 
 
-@pytest.mark.skip(reason="Pyuda client unavailable")
+def try_uda():
+    try:
+        import pyuda
+
+        client = pyuda.Client()
+        client.get("ip", 30421)
+        return False
+    except ImportError:
+        return True
+
+
+@pytest.mark.skipif(try_uda(), reason="Pyuda client unavailable")
 def test_load_uda():
     loader = UDALoader()
     signal = loader.load(30420, "ip")


### PR DESCRIPTION
There seems to be some issue with running the unit tests with the zarr version.

This fixes that issue, and as a bonus enables `pyuda` tests when the user is connected to the UKAEA VPN.

To test:
  - Run `uv run pytest`
  - Code review!