### PR TITLE
Fixed channel same name error

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -489,7 +489,7 @@ datasets:
              - "AMC_P5L FEED CURRENT"
              - "AMC_P5U FEED CURRENT"
         dimensions:
-          channel:
+          current_channel:
           time: 
             imas: "pf_active.coil[:].current.time"
 
@@ -515,7 +515,7 @@ datasets:
               - 'XDC_PF_F_P4'
               - 'XDC_PF_F_P5'
         dimensions:
-          channel:
+          voltage_channel:
           time: 
             imas: "pf_active.coil[:].voltage.time"
       


### PR DESCRIPTION
Closes issue: #70 

Small change to ensure different dimension names in `pf_active` profiles:

-  for `coil_current`: `channel` -> `current_channel` 
-  for `coil_voltage`: `channel` -> `voltage_channel`

Plots repeated from issue #70 after change to show change is as wanted and expected:

```
store = zarr.storage.DirectoryStore(f'/locally/ingested/shot/30421.zarr')

profiles = xr.open_zarr(store, group='pf_active')

plt.figure()
profiles['coil_current'].plot()
plt.figure()
profiles['coil_voltage'].plot()
``` 

![46f19d57-1c18-4d17-b9b9-9e6e3a48ee92](https://github.com/user-attachments/assets/227ebcf5-6678-4ca1-8af7-9161c09e4777)

![5d3be27b-4e1f-475c-be32-dc010d64704d](https://github.com/user-attachments/assets/d9d18cee-da98-480c-90e6-bdf4fa8f2810)



