### PR TITLE
add gas injection valves to mapping

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -423,7 +423,7 @@ datasets:
         source: 
           - name: "XDC/GAS/"
             shot_range:
-              shot_min: 28356
+              shot_min: 28356 #28356-28451 don't have xdc as source
               shot_max: 30471
             attributes: {
                     "fuelling_groups": {
@@ -512,7 +512,7 @@ datasets:
             #- "XDC_GAS_F_HFS" this comes and goes -  XDC_HFS_PUFF maybe an equivalent? 
           - name: "XDC/GAS/F"
             shot_range: #this range has HM12 not split up and HEOA/B are present
-              shot_min: 25912 #25912 - 25926 don't have xdc as a source 
+              shot_min: 25912 #25912 - 25936 don't have xdc as a source 
               shot_max: 26755
             attributes: {
                     "fuelling_groups": {
@@ -618,7 +618,7 @@ datasets:
               - "XDC_GAS_T_G12"
               #- "XDC_GAS_T_ECELMOD"
         dimensions:
-          valve_channel:
+          target_valve_channel:
           time:
             imas: "gas_injection.valve[:].target_voltage.time"
 

--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -425,7 +425,7 @@ datasets:
             shot_range:
               shot_min: 28356
               shot_max: 30471
-            groupings: {
+            attributes: {
                     "fuelling_groups": {
                         "/xdc/gas/t/g1": ["/xdc/gas/f/tc5a", "/xdc/gas/f/tc5b", "/xdc/gas/f/tc11"],
                         "/xdc/gas/t/g2": ["/xdc/gas/f/bc5"],
@@ -470,7 +470,7 @@ datasets:
             shot_range: #this range has HM12 split up into A and B, also when HM12A/B are present HEOA/B aren't
               shot_min: 26756
               shot_max: 28355
-            groupings: {
+            attributes: {
                     "fuelling_groups": {
                         "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
                         "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],
@@ -514,7 +514,7 @@ datasets:
             shot_range: #this range has HM12 not split up and HEOA/B are present
               shot_min: 25912 #25912 - 25926 don't have xdc as a source 
               shot_max: 26755
-            groupings: {
+            attributes: {
                     "fuelling_groups": {
                         "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
                         "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],

--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -192,7 +192,7 @@ datasets:
       li:
         source: "EFM_LI" 
         units: 'dimensionless'
-        imase_name: "equilibrium.time_slice[:].global_quantities.li_3"
+        imas: "equilibrium.time_slice[:].global_quantities.li_3" ####
         dimensions:
           time:
             imas: "equilibrium.time_slice[:].time"
@@ -417,49 +417,211 @@ datasets:
           time:
             imas: "gas_injection.time"
 
-      # valve_voltage:
-      #   imas: "gas_injection.valve[:].voltage.data"
-      #   source: 
-      #     - name: "XDC/GAS"
-      #       shot_range:
-      #         shot_min: 28356
-      #         shot_max: 30471
-      #       channels:
-      #         - "XDC/GAS/T/G1"
-      #         - "XDC/GAS/T/G2"
-      #         - "XDC/GAS/T/G3"
-      #         - "XDC/GAS/T/G4"
-      #         - "XDC/GAS/T/G5"
-      #         - "XDC/GAS/T/G6"
-      #         - "XDC/GAS/T/G7"
-      #         - "XDC/GAS/T/G8"
-      #         - "XDC/GAS/T/G9"
-      #         - "XDC/GAS/T/G10"
-      #         - "XDC/GAS/T/G11"
-      #         - "XDC/GAS/T/G12"
+      valve_voltage:
+        imas: "gas_injection.valve[:].voltage.data"
+        units: "V"
+        source: 
+          - name: "XDC/GAS/"
+            shot_range:
+              shot_min: 28356
+              shot_max: 30471
+            groupings: {
+                    "fuelling_groups": {
+                        "/xdc/gas/t/g1": ["/xdc/gas/f/tc5a", "/xdc/gas/f/tc5b", "/xdc/gas/f/tc11"],
+                        "/xdc/gas/t/g2": ["/xdc/gas/f/bc5"],
+                        "/xdc/gas/t/g3": ["/xdc/gas/f/hl1", "/xdc/gas/f/hu6", "/xdc/gas/f/hu8"],
+                        "/xdc/gas/t/g4": ["/xdc/gas/f/hu11"],
+                        "/xdc/gas/t/g11": ["/xdc/gas/f/ibfua", "/xdc/gas/f/ibfub"],
+                        "/xdc/gas/t/g12": ["/xdc/gas/f/ibfla", "/xdc/gas/f/ibflb"]
+                    },
+                    "impurity_groups": {
+                        "/xdc/gas/t/g5": ["/xdc/gas/f/hl11"],
+                        "/xdc/gas/t/g6": ["/xdc/gas/f/bc11"],
+                        "/xdc/gas/t/g7": ["/xdc/gas/f/hecc"],
+                        "/xdc/gas/t/g8": ["/xdc/gas/f/heoa", "/xdc/gas/f/heob"],
+                        "/xdc/gas/t/g9": ["/xdc/gas/f/hm12a", "/xdc/gas/f/hm12b"],
+                        "/xdc/gas/t/g10": ["/xdc/gas/f/ibil"],
+                        #"/xdc/gas/t/ecelmod": ["/xdc/gas/f/ecel"]
+                    }
+                  }
+            channels:
+              - '/xdc/gas/f/tc5a'
+              - '/xdc/gas/f/tc5b'
+              - '/xdc/gas/f/tc11'
+              - '/xdc/gas/f/bc5' #between 0 and 125V until 0.5s, then -60V
+              - '/xdc/gas/f/hl1'
+              - '/xdc/gas/f/hu6'
+              - '/xdc/gas/f/hu8'
+              - '/xdc/gas/f/hu11'
+              - '/xdc/gas/f/hl11'
+              - '/xdc/gas/f/bc11'
+              - '/xdc/gas/f/hecc'
+              - '/xdc/gas/f/heoa'
+              - '/xdc/gas/f/heob'
+              - '/xdc/gas/f/hm12a'
+              - '/xdc/gas/f/hm12b'
+              - '/xdc/gas/f/ibil'
+              - '/xdc/gas/f/ibfua'
+              - '/xdc/gas/f/ibfub'
+              - '/xdc/gas/f/ibfla'
+              - '/xdc/gas/f/ibflb'
+              #- '/xdc/gas/f/ecel'
+          - name: "XDC/GAS/F"
+            shot_range: #this range has HM12 split up into A and B, also when HM12A/B are present HEOA/B aren't
+              shot_min: 26756
+              shot_max: 28355
+            attrs: {
+                    "fuelling_groups": {
+                        "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
+                        "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],
+                        "XDC_GAS_T_G3": ["XDC_GAS_F_HL1", "XDC_GAS_F_HU6", "XDC_GAS_F_HU8"],
+                        "XDC_GAS_T_G4": ["XDC_GAS_F_HU11"],
+                        "XDC_GAS_T_G11": ["XDC_GAS_F_IBFUA", "XDC_GAS_F_IBFUB"],
+                        "XDC_GAS_T_G12": ["XDC_GAS_F_IBFLA", "XDC_GAS_F_IBFLB"]
+                    },
+                    "impurity_groups": {
+                        "XDC_GAS_T_G5": ["XDC_GAS_F_HL11"],
+                        "XDC_GAS_T_G6": ["XDC_GAS_F_BC11"],
+                        "XDC_GAS_T_G7": ["XDC_GAS_F_HECC"],
+                        "XDC_GAS_T_G8": ["XDC_GAS_F_HEOA", "XDC_GAS_F_HEOB"],
+                        "XDC_GAS_T_G9": ["XDC_GAS_F_HM12A", "XDC_GAS_F_HM12B"],
+                        "XDC_GAS_T_G10": ["XDC_GAS_F_IBIL"],
+                        #"XDC_GAS_T_ECELMOD": ["XDC_GAS_F_ECEL"]
+                    },
+                  }
+            channels:
+            - "XDC_GAS_F_TC5A"
+            - "XDC_GAS_F_TC5B"
+            - "XDC_GAS_F_TC11"
+            - "XDC_GAS_F_BC5"
+            - "XDC_GAS_F_HL1"
+            - "XDC_GAS_F_HU6"
+            - "XDC_GAS_F_HU8"
+            - "XDC_GAS_F_HU11"
+            - "XDC_GAS_F_HL11"
+            - "XDC_GAS_F_BC11"
+            - "XDC_GAS_F_HECC"
+            - "XDC_GAS_F_HM12A"
+            - "XDC_GAS_F_HM12B"
+            - "XDC_GAS_F_IBIL"
+            - "XDC_GAS_F_IBFUA"
+            - "XDC_GAS_F_IBFUB"
+            - "XDC_GAS_F_IBFLA"
+            - "XDC_GAS_F_IBFLB"
+            #- "XDC_GAS_F_ECEL" this comes and goes - ecelmod -> group 7 ECEL
+            #- "XDC_GAS_F_HFS" this comes and goes -  XDC_HFS_PUFF maybe an equivalent? 
+          - name: "XDC/GAS/F"
+            shot_range: #this range has HM12 not split up and HEOA/B are present
+              shot_min: 25912 #25912 - 25926 don't have xdc as a source 
+              shot_max: 26755
+            attrs: {
+                    "fuelling_groups": {
+                        "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
+                        "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],
+                        "XDC_GAS_T_G3": ["XDC_GAS_F_HL1", "XDC_GAS_F_HU6", "XDC_GAS_F_HU8"],
+                        "XDC_GAS_T_G4": ["XDC_GAS_F_HU11"],
+                        "XDC_GAS_T_G11": ["XDC_GAS_F_IBFUA", "XDC_GAS_F_IBFUB"],
+                        "XDC_GAS_T_G12": ["XDC_GAS_F_IBFLA", "XDC_GAS_F_IBFLB"]
+                    },
+                    "impurity_groups": {
+                        "XDC_GAS_T_G5": ["XDC_GAS_F_HL11"],
+                        "XDC_GAS_T_G6": ["XDC_GAS_F_BC11"],
+                        "XDC_GAS_T_G7": ["XDC_GAS_F_HECC"],
+                        "XDC_GAS_T_G8": ["XDC_GAS_F_HEOA", "XDC_GAS_F_HEOB"],
+                        "XDC_GAS_T_G9": ["XDC_GAS_F_HM12"],
+                        "XDC_GAS_T_G10": ["XDC_GAS_F_IBIL"],
+                        #"XDC_GAS_T_ECELMOD": ["XDC_GAS_F_ECEL"]
+                    },
+                  }
+            channels:
+              - "XDC_GAS_F_TC5A"
+              - "XDC_GAS_F_TC5B"
+              - "XDC_GAS_F_TC11"
+              - "XDC_GAS_F_BC5"
+              - "XDC_GAS_F_HL1"
+              - "XDC_GAS_F_HU6"
+              - "XDC_GAS_F_HU8"
+              - "XDC_GAS_F_HU11"
+              - "XDC_GAS_F_HL11"
+              - "XDC_GAS_F_BC11"
+              - "XDC_GAS_F_HECC"
+              - "XDC_GAS_F_HEOA" #this changes as g8  (which this is) becomes obsolete
+              - "XDC_GAS_F_HEOB" #so maybe can keep in and when they are there it will fill and when they are not ignored?
+              - "XDC_GAS_F_HM12" #this changes based on shot as well
+              - "XDC_GAS_F_IBIL"
+              - "XDC_GAS_F_IBFUA"
+              - "XDC_GAS_F_IBFUB"
+              - "XDC_GAS_F_IBFLA"
+              - "XDC_GAS_F_IBFLB"
+              #- "XDC_GAS_F_ECEL" this comes and goes - ecelmod -> group 7 ECEL
+              #- "XDC_GAS_F_HFS" this comes and goes -  XDC_HFS_PUFF maybe an equivalent? 
+          - name: "XDC/GAS/F"
+            shot_range:
+              shot_min: 1
+              shot_max: 25911
+            channels:
+              - "XDC_GAS_F_G1"
+              - "XDC_GAS_F_G2"
+              - "XDC_GAS_F_G3"
+              - "XDC_GAS_F_G4"
+              - "XDC_GAS_F_G5"
+              - "XDC_GAS_F_G6"
+              - "XDC_GAS_F_G7"
+              - "XDC_GAS_F_G8"
+              - "XDC_GAS_F_G9"
+              - "XDC_GAS_F_G10"
+              - "XDC_GAS_F_G11"
+              - "XDC_GAS_F_G12"
+        dimensions:
+          valve_channel:
+          time:
+            imas: "gas_injection.valve[:].voltage.time"
+    
+      valve_target_voltage:
+        imas: "gas_injection.valve[:].target_voltage.data"
+        units: "V"
+        source:
+          - name: "XDC/GAS/T"
+            shot_range:
+              shot_min: 28356
+              shot_max: 30471
+            channels:
+              - '/xdc/gas/t/g1'
+              - '/xdc/gas/t/g2' #units = 'V'  30421: 6 -> 5 -> 0 then it starts
+              - '/xdc/gas/t/g3' #units = 'V'  30421: 6 -> 5 -> 0 then it starts
+              - '/xdc/gas/t/g4'
+              - '/xdc/gas/t/g5'
+              - '/xdc/gas/t/g6'
+              - '/xdc/gas/t/g7'
+              - '/xdc/gas/t/g8'
+              - '/xdc/gas/t/g9'
+              - '/xdc/gas/t/g10'
+              - '/xdc/gas/t/g11'
+              - '/xdc/gas/t/g12'
+              #-'xdc/gas/t/ecelmod' #there are many e.g. g11sel - not sure what they do
+          - name: "XDC/GAS/T"
+            shot_range:
+              shot_min: 1
+              shot_max: 28355
+            channels:
+              - "XDC_GAS_T_G1"
+              - "XDC_GAS_T_G2"
+              - "XDC_GAS_T_G3"
+              - "XDC_GAS_T_G4"
+              - "XDC_GAS_T_G5"
+              - "XDC_GAS_T_G6"
+              - "XDC_GAS_T_G7"
+              - "XDC_GAS_T_G8" #this comes and goes
+              - "XDC_GAS_T_G9"
+              - "XDC_GAS_T_G10"
+              - "XDC_GAS_T_G11"
+              - "XDC_GAS_T_G12"
+              #- "XDC_GAS_T_ECELMOD"
+        dimensions:
+          valve_channel:
+          time:
+            imas: "gas_injection.valve[:].target_voltage.time"
 
-      #     - name: "XDC/GAS"
-      #       shot_range:
-      #         shot_min: 1
-      #         shot_max: 28355
-      #       channels:
-      #         - "XDC_GAS_T_G1"
-      #         - "XDC_GAS_T_G2"
-      #         - "XDC_GAS_T_G3"
-      #         - "XDC_GAS_T_G4"
-      #         - "XDC_GAS_T_G5"
-      #         - "XDC_GAS_T_G6"
-      #         - "XDC_GAS_T_G7"
-      #         - "XDC_GAS_T_G8"
-      #         - "XDC_GAS_T_G9"
-      #         - "XDC_GAS_T_G10"
-      #         - "XDC_GAS_T_G11"
-      #         - "XDC_GAS_T_G12"
-
-      #   dimensions:
-      #     valve_channel:
-      #     time: 
-      #       imas: "gas_injection.valve[:].voltage.time"
 
   pf_active:
     imas: "pf_active"

--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -470,7 +470,7 @@ datasets:
             shot_range: #this range has HM12 split up into A and B, also when HM12A/B are present HEOA/B aren't
               shot_min: 26756
               shot_max: 28355
-            attrs: {
+            groupings: {
                     "fuelling_groups": {
                         "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
                         "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],
@@ -514,7 +514,7 @@ datasets:
             shot_range: #this range has HM12 not split up and HEOA/B are present
               shot_min: 25912 #25912 - 25926 don't have xdc as a source 
               shot_max: 26755
-            attrs: {
+            groupings: {
                     "fuelling_groups": {
                         "XDC_GAS_T_G1": ["XDC_GAS_F_TC5A", "XDC_GAS_F_TC5B", "XDC_GAS_F_TC11"],
                         "XDC_GAS_T_G2": ["XDC_GAS_F_BC5"],

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -43,7 +43,7 @@ class Source(BaseModel):
     shot_range: Optional[ShotRange] = None
     channels: Optional[list[str]] = None
     background_correction: Optional[BackgroundCorrection] = None
-    groupings: Optional[dict] = None
+    attributes: Optional[dict] = None
 
 
 SourceType = Union[list[Source], str]

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -43,6 +43,7 @@ class Source(BaseModel):
     shot_range: Optional[ShotRange] = None
     channels: Optional[list[str]] = None
     background_correction: Optional[BackgroundCorrection] = None
+    groupings: Optional[dict] = None
 
 
 SourceType = Union[list[Source], str]

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -102,11 +102,11 @@ class DatasetReader:
         if profile.imas is not None:
             item.attrs["imas"] = profile.imas
 
-        if source.groupings is not None:
-            item.attrs["groupings"] = source.groupings
-
         item.attrs["description"] = profile.description
         item.attrs["name"] = profile_name
+
+        if source.groupings is not None:
+            item.attrs["groupings"] = source.groupings
 
         item = item.where(np.isfinite(item.values), np.nan)
         if profile.fill_value is not None:

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -105,8 +105,8 @@ class DatasetReader:
         item.attrs["description"] = profile.description
         item.attrs["name"] = profile_name
 
-        if source.groupings is not None:
-            item.attrs["groupings"] = source.groupings
+        if source.attributes is not None and isinstance(source.attributes, dict):
+            item.attrs.update(source.attributes)
 
         item = item.where(np.isfinite(item.values), np.nan)
         if profile.fill_value is not None:

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -102,6 +102,9 @@ class DatasetReader:
         if profile.imas is not None:
             item.attrs["imas"] = profile.imas
 
+        if source.groupings is not None:
+            item.attrs["groupings"] = source.groupings
+
         item.attrs["description"] = profile.description
         item.attrs["name"] = profile_name
 


### PR DESCRIPTION
Connected to issue #66 

I have split up the float gas injection as follows:

- 1 - 25911: valve names `XDC_GAS_F_G{#}`
- 25912 - 26755: valve names `XDC_GAS_F_{STRING}`, but the HM12 group has not been split into HM12A and HM12B
- 26756 - 28355: valve names `XDC_GAS_F_{STRING}`, HM12 is split into HM12A and HM12B
- 28356 - 30471: valve names `xdc/gas/f/{string}`

I have also added an attribute called `groupings`, not that happy with the name though, any other suggestions welcome.

the new attribute is a dictionary which states the mapping between the target and float valve groups, source of this can be found in #66 issue. 

I am slightly concerned that the mappings aren't correct after graphing the channels. For example, for 30421, the f and t channels are very different than they are for 11840.

For 30421 xdc/gas/t/g2 which is the target for xdc/gas/f/bc5 :

<figure markdown>
  <img src="https://github.com/user-attachments/assets/82c47d16-3482-411b-8f16-abd5ecd0d100" alt="Alt Text" width="375">
  <img src="https://github.com/user-attachments/assets/e60a2b23-de22-4d02-8b00-f4f9da72526c" alt="Alt Text" width="400">
<figure>

For 11840 XDC_GAS_T_G2 which is the target for XDC_GAS_F_G2 :

<figure markdown>
  <img src="https://github.com/user-attachments/assets/0a8518cf-9b49-4788-b1de-524ca6b40e86" alt="Alt Text" width="385">
  <img src="https://github.com/user-attachments/assets/ab4444f8-f654-4a5f-a01c-667273ab8acf" alt="Alt Text" width="385">
<figure>


I have ecel and hfs groups included but commented out. Ecel was mentioned in the mapping in the issue but doesn't follow the same structure as the other groupings so was not sure if it wanted to be included or not.