### PR TITLE
delete uda_name attr from level2 dataset

### DIFF
--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -169,7 +169,8 @@ class DatasetReader:
             "name": "Creative Commons 4.0 BY-SA",
             "url": "https://creativecommons.org/licenses/by-sa/4.0/",
         }
-        del dataset.attrs["uda_name"]
+
+        del dataset.attrs["uda_name"] # Bug with level 2 uda_name attribute, deleted here
         return dataset
 
     def _parse_units(self, item: xr.DataArray):


### PR DESCRIPTION
Fixes bugged attribute "uda_name" from level 2 ingestion which does not work as intended. 

Just deletes the attribute from the dataset at the end. As attributes are loaded universally for both L1 and L2 from the `src/core/load.py` code, not as simple to fix with a conditional