### PR TITLE
Fix xpoint_r/z channel names

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -106,7 +106,7 @@ datasets:
         units: "dimensionless"
         fill_value: -999
         dimensions:
-          n_x_points:
+          n_x_points_r:
           time:
             imas: "equilibrium.time_slice[:].time"
 
@@ -120,7 +120,7 @@ datasets:
         units: "dimensionless"
         fill_value: -999
         dimensions:
-          n_x_points:
+          n_x_points_z:
           time:
             imas: "equilibrium.time_slice[:].time"
 


### PR DESCRIPTION
Fixes #82 

To Test:

Run:
```
python3 -m src.level2.main mappings/level2/mast.yml -v --shot 30421 -i equilibrium -o ./local-test
```

And check that the `x_point_r` and `x_point_z` have different channel names. Check they are also of size 2!