### PR TITLE
Ensure L2 Interpolation Alignment

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -2061,7 +2061,7 @@ datasets:
         source:
           - name: "AMC" 
             channels:
-             - "AMC_SOL CURRENT" #: {scale: 0.5} # Exception to P1 / solenoid where you only have AMC_SOL CURRENT which is the feed current (but you have to multiply by 0.5 because of it being wired in parallel)
+             - "AMC_SOL CURRENT" : {scale: 0.5} # Exception to P1 / solenoid where you only have AMC_SOL CURRENT which is the feed current (but you have to multiply by 0.5 because of it being wired in parallel)
              - "AMC_P2IL FEED CURRENT"
              - "AMC_P2IU FEED CURRENT"
              - "AMC_P2OL FEED CURRENT"

--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -1,23 +1,18 @@
 facility: "MAST"
 default_loader: "uda"
 plasma_current: "summary/ip"
-
-global_interpolate:
-  params:
-    time:
-      step: 0.00025
-      method: 'zero'
-      dropna: true
+default_start: -0.1
 
 datasets:
   equilibrium:
     imas: "equilibrium"
     description: "Description of a 2D, axi-symmetric, tokamak equilibrium; result of an equilibrium code."
-
     interpolate:
       time:
-        step: 5.0e-3
-        dropna: True
+        start: -0.1
+        step: 5e-3
+        method: 'zero'
+        dropna: true
       z:
         method: "none"
       major_radius:
@@ -328,6 +323,12 @@ datasets:
   pulse_schedule:
     imas: pulse_schedule
     description: "Description of Pulse Schedule, described by subsystems waveform references and an envelope around them. The controllers, pulse schedule and SDN are defined in separate IDSs."
+    interpolate:
+      time:
+        start: -0.1
+        step: 5e-5
+        method: 'zero'
+        dropna: true
     profiles:
       i_plasma:
         target_units: "A"
@@ -380,6 +381,12 @@ datasets:
       Dynamic quantities are either taken at given time slices (indicated in the “time” vector) or 
       time-averaged over an interval (in such case the “time_width” of the interval is indicated 
       and the “time” vector represents the end of each time interval)."
+    interpolate:
+      time:
+        start: -0.1
+        step: 1e-3
+        method: 'zero'
+        dropna: true
     profiles:
       ip:
         source: "AMC_PLASMA CURRENT"
@@ -436,8 +443,13 @@ datasets:
   bolometer:
     imas: "bolometer"
     description: "Bolometer diagnostic: per-chord radiated signal and line-of-sight geometry from the MAST ABM array."
+    interpolate:
+      time:
+        start: -0.1
+        step: 5e-4
+        method: 'zero'
+        dropna: true
     profiles:
-
       power:
         imas: "bolometer.channel[:].power.data"
         source: "ABM_I-BOL"
@@ -522,6 +534,12 @@ datasets:
   interferometer:
     imas: "interferometer"
     description: "Interferometer diagnostic"
+    interpolate:
+      time:
+        start: -0.1
+        step: 2e-5
+        method: 'zero'
+        dropna: true
     profiles:
       n_e_line:
         source: "ANE_DENSITY"
@@ -533,6 +551,12 @@ datasets:
   controllers:
     imas: "controllers"
     description: "Plasma control system states, proxies, and feedback signals."
+    interpolate:
+      time:
+        start: -0.1
+        step: 5e-5
+        method: 'zero'
+        dropna: true
     profiles:
       zip_proxy:
         source:
@@ -553,6 +577,12 @@ datasets:
   gas_injection:
     imas: "gas_injection"
     description: "Gas injection by a system of pipes and valves."
+    interpolate:
+      time:
+        start: -0.1
+        step: 5e-5
+        method: 'zero'
+        dropna: true
     profiles:
       total_injected:
         source: "AGA_INTEG_GAS"
@@ -783,7 +813,6 @@ datasets:
           time:
             imas: "gas_injection.valve[:].target_voltage.time"
 
-
   pf_passive:
     imas: "pf_passive"
     description: "Description of the axisymmetric passive conductors, currents 
@@ -792,9 +821,6 @@ datasets:
       the component-related IDS (e.g. wall) which are used to store e.g. the 
       component machine description"
     profiles:
-
-      # - add UDA data here - #
-
       botcol_r:
         geometry:
           stem: "centrecolumn/botcol"
@@ -2017,12 +2043,17 @@ datasets:
         dimensions:
           coil_cases_geometry_channel:
 
-
   pf_active:
     imas: "pf_active"
     desctription: "Description of the axisymmetric active poloidal field (PF) 
       coils and supplies; includes the limits of these systems; includes the 
       forces on them; does not include non-axisymmetric coil systems"
+    interpolate:
+      time:
+        start: -0.1
+        step: 5e-5
+        method: 'zero'
+        dropna: true
     profiles:
       coil_current:
         imas: "pf_active.coil[:].current.data"
@@ -2030,7 +2061,7 @@ datasets:
         source:
           - name: "AMC" 
             channels:
-             - "AMC_SOL CURRENT": {scale: 0.5} # Exception to P1 / solenoid where you only have AMC_SOL CURRENT which is the feed current (but you have to multiply by 0.5 because of it being wired in parallel)
+             - "AMC_SOL CURRENT" #: {scale: 0.5} # Exception to P1 / solenoid where you only have AMC_SOL CURRENT which is the feed current (but you have to multiply by 0.5 because of it being wired in parallel)
              - "AMC_P2IL FEED CURRENT"
              - "AMC_P2IU FEED CURRENT"
              - "AMC_P2OL FEED CURRENT"
@@ -2758,27 +2789,30 @@ datasets:
         dimensions:
           sol_coordinate_element:
 
-
   magnetics:
-    interpolate:
-      time:
-        step: 0.0002
-        method: 'zero'
-
-      time_saddle:
-        step: 2e-5
-        method: 'zero'
-
-      time_mirnov:
-        step: 2e-6
-        method: 'zero'
-
-      time_omaha:
-        step: 1e-7
-        method: 'zero'
-
     imas: "magnetics"
     description: "Magnetic diagnostics for equilibrium identification and plasma shape control."
+    interpolate:
+      time:
+        start: -0.1 
+        step: 2e-4
+        method: 'zero'
+        dropna: true
+      time_saddle:
+        start: -0.1
+        step: 2e-5
+        method: 'zero'
+        dropna: true
+      time_mirnov:
+        start: -0.1
+        step: 2e-6
+        method: 'zero'
+        dropna: true
+      time_omaha:
+        start: -0.1
+        step: 5e-7
+        method: 'zero'
+        dropna: true
     profiles:
       ip: 
         imas: "magnetics.ip[:].data"
@@ -3754,13 +3788,19 @@ datasets:
             imas: "magnetics.b_field_tor_probe[:].voltage.time"
 
   spectrometer_visible:
-    interpolate:
-      time: 
-        step: 2e-5
-      time_bes:
-        step: 5e-7
     imas: "spectrometer_visible"
     description: "Spectrometer in visible light range diagnostic"
+    interpolate:
+      time: 
+        start: -0.01
+        step: 2e-5
+        method: 'zero'
+        dropna: true
+      time_bes:
+        start: -0.01
+        step: 5e-7
+        method: 'zero'
+        dropna: true
 
     profiles:
       filter_spectrometer_dalpha_voltage:
@@ -3827,15 +3867,15 @@ datasets:
         dimensions:
           time:
           
-
   thomson_scattering:
     imas: thomson_scattering
     description: "Thomson scattering diagnostic"
     interpolate:
       time:
-        step: 0.005
+        start: 0 # diagnostic doesn't pre-trigger
+        step: 5e-35
         fill: 'none'
-        dropna: False
+        dropna: false
       major_radius:
         start: 0.3
         end: 1.5
@@ -3956,8 +3996,10 @@ datasets:
     descripton: "Charge exchange spectroscopy diagnostic."
     interpolate:
       time:
-        step: 0.005
+        start: -0.1
+        step: 5e-3
         method: 'zero'
+        dropna: true
       major_radius:
         start: 0
         end: 1.6
@@ -3986,14 +4028,16 @@ datasets:
           
           major_radius:
             imas: "charge_exchange.channel[:].position.r" 
-
-            
+     
   soft_x_rays:
-    interpolate:
-      time:
-        step: 2e-5
     imas: "soft_x_rays"
     description: "Soft X-rays tomography diagnostic"
+    interpolate:
+      time:
+        start: -0.1
+        step: 2e-6
+        method: 'zero'
+        dropna: true
     profiles:
       tangential_cam:
         source: 
@@ -4550,12 +4594,11 @@ datasets:
           outer_vertical_cam_geometry_channel:
 
   camera_visible:
-    interpolate:
-      time:
-        step: 0.002
-
     imas: "camera_visible"
     description: "Camera in the visible light range."
+    interpolate:
+      time:
+        method: 'none'
     profiles:
       camera_lower:
         source: "RBA"
@@ -4591,9 +4634,7 @@ datasets:
   wall:
     imas: "wall"
     description: "Description of the torus wall and its interaction with the plasma"
-
     profiles:
-
       limiter_r:
         geometry:
           stem: "efit"
@@ -4606,7 +4647,6 @@ datasets:
         source: ""
         dimensions:
           limiter_geometry_channel:
-
       limiter_z:
         geometry:
           stem: "efit"

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -4,7 +4,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Optional, Union
 
-import numpy as np
 import yaml
 from pydantic import BaseModel, Field, field_validator
 

--- a/src/core/model.py
+++ b/src/core/model.py
@@ -23,10 +23,6 @@ class InterpolationParams(BaseModel):
     fill: Optional[FillOptions] = None
     dropna: Optional[bool] = None
 
-    @property
-    def coords(self) -> np.ndarray:
-        return np.arange(self.start, self.end, self.step)
-
 
 class ShotRange(BaseModel):
     shot_min: int = Field(gt=0)
@@ -98,19 +94,14 @@ class DatasetInfo(BaseModel):
     description: Optional[str] = ""
 
 
-class GlobalInterpolateParams(BaseModel):
-    tmin: Optional[float] = None
-    tmax: Optional[float] = None
-    params: Optional[dict[str, InterpolationParams]] = {}
-
-
 class Mapping(BaseModel):
     facility: str
     default_loader: str
     plasma_current: str
     dataset_defaults: Optional[dict[str, str]] = None
     datasets: dict[str, DatasetInfo]
-    global_interpolate: Optional[GlobalInterpolateParams] = None
+    default_start: Optional[float] = None
+    tmax: Optional[float] = None
 
 
 def load_yaml(config_file: str) -> dict[str, Any]:

--- a/src/level2/main.py
+++ b/src/level2/main.py
@@ -105,14 +105,7 @@ def set_mapping_time_bounds(
         raise RuntimeError(f"No Plasma Current for shot {shot}")
 
     plasma_current = trim_ip_range(plasma_current, tdelta)
-
-    if mapping.global_interpolate.tmin is None:
-        tmin = float(plasma_current.time.values.min())
-        mapping.global_interpolate.tmin = tmin
-
-    if mapping.global_interpolate.tmax is None:
-        tmax = float(plasma_current.time.values.max())
-        mapping.global_interpolate.tmax = tmax
+    mapping.tmax = float(plasma_current.time.values.max())
 
 
 

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -180,8 +180,7 @@ class DatasetReader:
 
     def apply_interpolation(self, dataset: xr.Dataset, dataset_name: str) -> xr.Dataset:
         dataset_config = self._mapping.datasets[dataset_name]
-        global_params = self._mapping.global_interpolate
-        interpolator = DatasetInterpolationTransform(dataset_config, global_params)
+        interpolator = DatasetInterpolationTransform(dataset_config, self._mapping)
         dataset = interpolator.transform(dataset)
         return dataset
 

--- a/src/level2/transforms.py
+++ b/src/level2/transforms.py
@@ -1,7 +1,7 @@
+import math
 import warnings
 from abc import ABC
 from typing import Union
-import math
 
 import numpy as np
 import scipy.signal
@@ -12,8 +12,8 @@ from src.core.model import (
     DatasetInfo,
     Dimension,
     FillOptions,
-    Mapping,
     InterpolationParams,
+    Mapping,
 )
 from src.core.registry import Registry
 

--- a/src/level2/transforms.py
+++ b/src/level2/transforms.py
@@ -1,6 +1,7 @@
 import warnings
 from abc import ABC
 from typing import Union
+import math
 
 import numpy as np
 import scipy.signal
@@ -11,7 +12,7 @@ from src.core.model import (
     DatasetInfo,
     Dimension,
     FillOptions,
-    GlobalInterpolateParams,
+    Mapping,
     InterpolationParams,
 )
 from src.core.registry import Registry
@@ -52,9 +53,9 @@ class BaseDatasetTransform(ABC):
 
 class DatasetInterpolationTransform(BaseDatasetTransform):
     def __init__(
-        self, dataset_params: DatasetInfo, global_params: GlobalInterpolateParams
+        self, dataset_params: DatasetInfo, mapping: Mapping
     ):
-        self.global_params = global_params
+        self.mapping = mapping
         self.dataset_params = dataset_params
 
     def transform_array(self, signal_name: str, signal: xr.DataArray):
@@ -68,22 +69,13 @@ class DatasetInterpolationTransform(BaseDatasetTransform):
         self, dataset: xr.Dataset, dim_name: str, params: InterpolationParams
     ) -> xr.Dataset:
         params = params.model_copy()
+        end_was_explicit = params.end is not None
 
-        if params.start is None and self.global_params.tmin is None:
-            params.start = float(dataset.coords[dim_name].values.min())
-        elif params.start is None and self.global_params.tmin is not None:
-            params.start = float(self.global_params.tmin)
-
-        if params.end is None and self.global_params.tmax is None:
-            params.end = dataset.coords[dim_name].values.max()
-        elif params.end is None and self.global_params.tmax is not None:
-            params.end = self.global_params.tmax
-
-        if dim_name in self.global_params.params:
-            global_param_dict = self.global_params.params[dim_name].model_dump()
-            for name, value in global_param_dict.items():
-                if getattr(params, name) is None:
-                    setattr(params, name, value)
+        if not end_was_explicit:
+            if self.mapping.tmax is not None:
+                params.end = float(self.mapping.tmax)
+            else:
+                params.end = float(dataset.coords[dim_name].values.max())
 
         if params.fill == FillOptions.FFILL:
             dataset = dataset.ffill(dim=dim_name)
@@ -97,11 +89,47 @@ class DatasetInterpolationTransform(BaseDatasetTransform):
         if params.method == "none":
             return dataset
 
+        if params.start is None:
+            if self.mapping.default_start is None:
+                raise ValueError(
+                    f"Dimension '{dim_name}' has no `start` set, and "
+                    f"`default_start` is not configured in the mapping. "
+                    f"Set one in the dataset's `interpolate` block or "
+                    f"add `default_start` to the top of the mapping YAML."
+                )
+            params.start = self.mapping.default_start
+
+        if params.step is None:
+            raise ValueError(
+                f"Dimension '{dim_name}' has no `step` in the dataset's "
+                f"`interpolate` block — cannot infer a default."
+            )
+
+        coords = self._build_aligned_grid(
+            params.start, params.end, params.step, end_was_explicit
+        )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            dataset = dataset.interp({dim_name: params.coords}, method=params.method)
-
+            dataset = dataset.interp({dim_name: coords}, method=params.method)
         return dataset
+
+    @staticmethod
+    def _build_aligned_grid(
+        start: float, end: float, step: float, end_was_explicit: bool
+    ) -> np.ndarray:
+        if step <= 0:
+            raise ValueError(f"Interpolation step must be positive, got {step}")
+        if end < start:
+            raise ValueError(f"end ({end}) must be >= start ({start})")
+
+        bin_float_tol = 1e-9
+        extent_in_bins = (end - start) / step
+        if end_was_explicit:
+            n = math.floor(extent_in_bins + bin_float_tol)
+        else:
+            n = math.ceil(extent_in_bins - bin_float_tol)
+        n = max(n, 0)
+        return start + np.arange(n + 1) * step
 
     def interpolate_dimensions(
         self,
@@ -109,17 +137,12 @@ class DatasetInterpolationTransform(BaseDatasetTransform):
         dimensions: dict[str, Dimension],
         interpolate_params: dict[str, InterpolationParams] = None,
     ) -> xr.Dataset:
+        if interpolate_params is None:
+            return dataset
         for dim_name in dimensions.keys():
-            if interpolate_params is not None and dim_name in interpolate_params:
+            if dim_name in interpolate_params:
                 dataset = self.interpolate_dimension(
                     dataset, dim_name, interpolate_params[dim_name]
-                )
-            elif self.global_params is None:
-                pass
-            elif dim_name in self.global_params.params:
-                interpolate_params = self.global_params.params[dim_name]
-                dataset = self.interpolate_dimension(
-                    dataset, dim_name, interpolate_params
                 )
         return dataset
 
@@ -162,7 +185,7 @@ class FFTDecomposeTransform(BaseDatasetTransform):
         return signal
 
 class BackgroundSubtractionTransform(BaseDatasetTransform):
-    def __init__(self, start:int, end: int):
+    def __init__(self, start: int, end: int):
         self.start = start
         self.end = end
 

--- a/tests/level2/test_reader.py
+++ b/tests/level2/test_reader.py
@@ -1,5 +1,10 @@
+import numpy as np
+import xarray as xr
+
 from src.core.load import UDALoader
+from src.core.model import Mapping
 from src.level2.reader import DatasetReader
+from src.level2.transforms import DatasetInterpolationTransform, InterpolationParams
 
 
 def test_read_profiles(mocker, sample_mapping, sample_dataarray):
@@ -34,3 +39,22 @@ def test_read_profile_with_background_subtraction(mocker, sample_mapping, sample
     background_mean = sample_dataarray.isel(time=slice(0, 5)).mean(dim="time")
     expected = sample_dataarray - background_mean
     assert (profile == expected).all()
+
+def test_interpolation_aligns_grids_across_shots():
+    mapping = Mapping(
+        facility="MAST", default_loader="uda",
+        plasma_current="summary/ip", datasets={},
+    )
+    transform = DatasetInterpolationTransform(None, mapping)
+    params = InterpolationParams(start=-0.1, step=2.5e-4, method="zero")
+
+    t_a = np.arange(-0.05, 0.10, 1.5e-3)
+    t_b = np.arange(-0.06, 0.20, 1.3e-3)
+    a = xr.DataArray(np.ones(len(t_a)), dims=["time"], coords={"time": t_a}, name="x").to_dataset()
+    b = xr.DataArray(np.ones(len(t_b)), dims=["time"], coords={"time": t_b}, name="x").to_dataset()
+
+    a_out = transform.interpolate_dimension(a, "time", params)
+    b_out = transform.interpolate_dimension(b, "time", params)
+
+    n = min(len(a_out.time), len(b_out.time))
+    assert np.allclose(a_out.time.values[:n], b_out.time.values[:n])


### PR DESCRIPTION
Closes #99 

Bug highlighted in issue 99:
> Expected behaviour of L2 data is that time coords are consistent between shots. This is not the case currently. Time is interpolated to a common time step but due to ranges being inconsistent time points do not match up.

Cause: 
Interpolation start time is calculated via the plasma current. Hence, two shots with similar but non-identical plasma onset produce disjointed time bases despite sharing the same time step. See #92 for detailed explanation.

Global interpolation has been removed in favour of source specific interpolation parameters. This is due to different sources having different median bins and so should not default to the same.

Now has a uniform start, most sources beginning at -0.1s. ~95% of shots have plasma onset in [-0.13, -0.04] with outliers starting before that (earliest found being -0.92). So we may way to increase the start time to -0.15 encapsulate more of this, however it will cause more shots with excess NaNs at the beginning of the shot.

To find the most sensible time bins for sources I did an analysis of 300 shots to see what median time bins were found. Some sources had large variances.
Summary caused some issues due to it being a mixture of different signals that aren't that similar the variation of time axis bins varied greatly. We may want to add more time base variations for it as was done with the magnetics source. But as summary is not necessarily used for analysis it may not be necessary.

When this is merged it will allow the PR #98 which adds `shot_id` as a dimension to allow concat between shots.


