### PR TITLE
Add plasma volume

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -213,6 +213,15 @@ datasets:
         dimensions:
           time:
             imas: "equilibrium.time_slice[:].time"
+
+      volume:
+        source: "EFM_PLASMA_VOLUME" 
+        imas: "equilibrium.time_slice[:].global_quantities.volume"
+        description: "Plasma volume"
+        dimensions:
+          time:
+            imas: "equilibrium.time_slice[:].time"
+
       q_axis:
         source: "EFM_Q_AXIS" 
         units: 'dimensionless'
@@ -261,6 +270,7 @@ datasets:
             imas: "equilibrium.time_slice[:].time"
           n_boundary_coords:
             units: 'dimensionless'
+
       wmhd:
         source: "EFM_WPLASMD" 
         dimensions:


### PR DESCRIPTION
Need to add the plasma volume into the EFIT data.

With this additional parameter & @LariDG's edits I think I've been able to compute the triple product for MAST shots:

<img width="1189" height="1590" alt="image" src="https://github.com/user-attachments/assets/12591c34-acb2-4be6-8d17-83cb96e4419c" />
