### PR TITLE
Fix/small ingestion fixes

### DIFF
--- a/src/core/load.py
+++ b/src/core/load.py
@@ -505,10 +505,7 @@ class UDALoader(BaseLoader):
 
 _uda_loader = UDALoader()
 
-@lru_cache()
 def _fetch_uda_geometry_tree(path: str, shot):
-    """Fetch a UDA geometry tree for a (path, shot) pair. `shot` may be a
-    file path (current convention) or an int shot number (future)."""
     client = _uda_loader._get_client()
     return client.geometry(path, shot, no_cal=True)
 

--- a/src/core/workflow_manager.py
+++ b/src/core/workflow_manager.py
@@ -26,7 +26,7 @@ class WorkflowManager:
     def initialize_client(self, n_workers: Optional[int] = None) -> Client:
         config.set({
             "distributed.scheduler.locks.lease-timeout": "inf",
-            "distributed.scheduler.worker-ttl": "30min",
+            "distributed.scheduler.worker-ttl": "30minutes",
         })
 
         try:

--- a/src/core/workflow_manager.py
+++ b/src/core/workflow_manager.py
@@ -24,7 +24,10 @@ class WorkflowManager:
             logger.info(f"Done shot {i+1}/{n} = {(i+1)/n*100:.2f}%")
 
     def initialize_client(self, n_workers: Optional[int] = None) -> Client:
-        config.set({"distributed.scheduler.locks.lease-timeout": "inf"})
+        config.set({
+            "distributed.scheduler.locks.lease-timeout": "inf",
+            "distributed.scheduler.worker-ttl": "30min",
+        })
 
         try:
             # Try and get MPI, if not use dask

--- a/src/level1/builder.py
+++ b/src/level1/builder.py
@@ -41,33 +41,38 @@ class DatasetBuilder:
             return
 
         for dataset_info in dataset_infos:
-            group_name = dataset_info.name
+            group_name = getattr(dataset_info, "name", str(dataset_info))
+            try:
+                logger.info(f"Loading dataset {group_name} for shot #{shot}")
+                datasets = self.load_datasets(shot, group_name)
 
-            logger.info(f"Loading dataset {group_name} for shot #{shot}")
-            datasets = self.load_datasets(shot, group_name)
+                if len(datasets) == 0:
+                    logger.warning(f"No datasets found for {group_name} in shot #{shot}")
+                    continue
 
-            if len(datasets) == 0:
-                logger.warning(f"No datasets found for {group_name} in shot #{shot}")
-                continue
+                logger.info(f"Processing {group_name} for shot #{shot}")
+                pipeline = self.pipelines.get(group_name)
 
-            logger.info(f"Processing {group_name} for shot #{shot}")
-            pipeline = self.pipelines.get(group_name)
+                dataset: xr.Dataset = pipeline(datasets)
+                dataset, group_name = self._rename_group(dataset, group_name)
 
-            dataset: xr.Dataset = pipeline(datasets)
-            dataset, group_name = self._rename_group(dataset, group_name)
+                dataset.attrs["name"] = group_name
+                dataset.attrs["description"] = dataset_info.description
+                dataset.attrs["quality"] = dataset_info.quality
+                if self.license_name is not None:
+                    dataset.attrs["license_name"] = self.license_name
+                if self.license_url is not None:
+                    dataset.attrs["license_url"] = self.license_url
+                dataset.attrs.update(get_ingestion_provenance())
 
-            dataset.attrs["name"] = group_name
-            dataset.attrs["description"] = dataset_info.description
-            dataset.attrs["quality"] = dataset_info.quality
-            if self.license_name is not None:
-                dataset.attrs["license_name"] = self.license_name
-            if self.license_url is not None:
-                dataset.attrs["license_url"] = self.license_url
-            dataset.attrs.update(get_ingestion_provenance())
+                logger.info(f"Writing {group_name} for shot #{shot}")
+                file_name = f"{shot}.{self.writer.file_extension}"
+                self.writer.write(file_name, group_name, dataset)
 
-            logger.info(f"Writing {group_name} for shot #{shot}")
-            file_name = f"{shot}.{self.writer.file_extension}"
-            self.writer.write(file_name, group_name, dataset)
+            except Exception:
+                logger.exception(
+                    f"Failed to ingest {group_name} for shot #{shot}; continuing with next source"
+                )
 
     def load_datasets(self, shot, group_name: str) -> dict[str, xr.Dataset]:
         signal_infos = self.loader.list_signals(shot)

--- a/src/level2/reader.py
+++ b/src/level2/reader.py
@@ -212,8 +212,8 @@ class DatasetReader:
         return dataset
 
     def add_shot_dimension(self, dataset: xr.Dataset) -> xr.Dataset:
-        if "shot_id" not in dataset.dims:
-            dataset = dataset.expand_dims(shot_id=[str(self._shot)])
+        if "shot_id" not in dataset.coords:
+            dataset = dataset.assign_coords(shot_id=self._shot)
         return dataset
 
     def _parse_units(self, item: xr.DataArray):


### PR DESCRIPTION
Making small fixes for the current ingestion.

### Changes Made
- Changing `shot_id` dimension to just a coordinate to stop the need for `squeeze()`
- Taking `lru_cache` out of geometry get for now due to client errors, keeping it for metadata as is extracted as pure `json` - this still makes for a speed improvement

### Pending
- Adding an exception for level1 in `builder.py` to stop ingestion skipping whole shots if a source has an error.