### PR TITLE
Scale PF currents and add EFIT PF current constraints

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -34,6 +34,8 @@ datasets:
         method: "none"
       psi_norm:
         method: "none"
+      n_pf_current:
+        method: "none"
 
     profiles:
       q:
@@ -359,6 +361,15 @@ datasets:
         dimensions:
           time:
             imas: "equilibrium.time_slice[:].time"
+
+      pf_current:
+        source: "EFM_FCOIL_(X)"
+        imas: "equilibrium.time_slice[:].constraints.pf_current"
+        units: "A"
+        dimensions:
+          time:
+            imas: "equilibrium.time_slice[:].time"
+          n_pf_current:
 
   pulse_schedule:
     imas: pulse_schedule
@@ -2374,19 +2385,19 @@ datasets:
         source:
           - name: "AMC" 
             channels:
-             - "AMC_SOL CURRENT" : {scale: 0.5} # Exception to P1 / solenoid where you only have AMC_SOL CURRENT which is the feed current (but you have to multiply by 0.5 because of it being wired in parallel)
-             - "AMC_P2IL FEED CURRENT"
-             - "AMC_P2IU FEED CURRENT"
-             - "AMC_P2OL FEED CURRENT"
-             - "AMC_P2OU FEED CURRENT"
-             - "AMC_P3L FEED CURRENT"
-             - "AMC_P3U FEED CURRENT"
-             - "AMC_P4L FEED CURRENT"
-             - "AMC_P4U FEED CURRENT"
-             - "AMC_P5L FEED CURRENT"
-             - "AMC_P5U FEED CURRENT"
-             - "AMC_P6L CURRENT" : {scale: 0.25}
-             - "AMC_P6U CURRENT" : {scale: 0.25}
+             - "AMC_SOL CURRENT" 
+             - "AMC_P2IL FEED CURRENT" : { scale: 12} # Feed current is in kA/turn. Each channel needs to be scaled by the number of turns in the coil to get the actual current in A.
+             - "AMC_P2IU FEED CURRENT" : { scale: 12}
+             - "AMC_P2OL FEED CURRENT": { scale: 8}
+             - "AMC_P2OU FEED CURRENT": { scale: 8}
+             - "AMC_P3L FEED CURRENT": { scale: 8}
+             - "AMC_P3U FEED CURRENT" : { scale: 8}
+             - "AMC_P4L FEED CURRENT": { scale: 23}
+             - "AMC_P4U FEED CURRENT": { scale: 23}
+             - "AMC_P5L FEED CURRENT": { scale: 23}
+             - "AMC_P5U FEED CURRENT": { scale: 23}
+             - "AMC_P6L CURRENT" 
+             - "AMC_P6U CURRENT"
         dimensions:
           current_channel:
           time: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ s5cmd
 scipy
 sqlalchemy
 uda
+uda-mast
 xarray
 zarr>=3
 # git+ssh://git@git.ccfe.ac.uk/MAST-U/mastcodes.git@release/1.3.10#subdirectory=uda/python


### PR DESCRIPTION
Turns out the feed current pf_active coils in UDA are actually in units of `kA/turn`, which means that the units UDA were incorrect.
 
As Kamran suggested I dived into the EFIT inputs directly to compare them to the recorded pf_active currents. I can see that the feed currents are not scaled correctly, as shown in the plot below. This is almost certainty why Stan was getting bad equilibria.
 
<img width="1860" height="1140" alt="image" src="https://github.com/user-attachments/assets/8687fbd2-214a-413b-a2d0-2999f8746599" />

 
After correctly the applying the scale factor for the number of turns to each coil and comparing, I get the plot below, whch looks much more sensible!
 
 
<img width="1860" height="1140" alt="image" src="https://github.com/user-attachments/assets/3e041494-8488-4c80-aa7b-11899d850288" />

 
Regenerating the Zarr file with the corrections applied and rerunning FreeGSNKE on the example that was flipping for Stan gives the following result:
 
 
<img width="1540" height="990" alt="image" src="https://github.com/user-attachments/assets/eac6050a-d585-4749-a578-5e7b0a0b22ac" />
