### PR TITLE
Add P6 voltage signal

### DIFF
--- a/mappings/level2/mast.yml
+++ b/mappings/level2/mast.yml
@@ -2420,6 +2420,7 @@ datasets:
               - '/xdc/pf/f/p2'
               - '/xdc/pf/f/p4'
               - '/xdc/pf/f/p5'
+              - 'XPC_FA DRIVE' # P6 voltage from analog control
           - name: "XDC/PF"
             shot_range:
               shot_min: 11695
@@ -2434,6 +2435,7 @@ datasets:
               - 'XDC_PF_F_P2'
               - 'XDC_PF_F_P4'
               - 'XDC_PF_F_P5'
+              - 'XPC_FA DRIVE' # P6 voltage from analog control
         dimensions:
           voltage_channel:
           time: 


### PR DESCRIPTION
After a long chat with Graham, I believe this added quantity is the voltage signal for the P6 coil. Different from the others as this as a analog controller outside of PCS.